### PR TITLE
fix: skip health check for go-waku

### DIFF
--- a/src/node/waku_node.py
+++ b/src/node/waku_node.py
@@ -208,12 +208,13 @@ class WakuNode:
 
             logger.info("Node protocols are initialized !!")
 
-        @retry(stop=stop_after_delay(5), wait=wait_fixed(0.1), reraise=True)
+        @retry(stop=stop_after_delay(timeout_duration), wait=wait_fixed(0.1), reraise=True)
         def check_ready(node=self):
             node.info_response = node.info()
             logger.info("REST service is ready !!")
 
-        check_healthy()
+        if self.is_nwaku():
+            check_healthy()
         check_ready()
 
     def get_enr_uri(self):


### PR DESCRIPTION
Skip health check for go-waku. It supports health endpoint for RLN only, and we don't use go-waku to RLN testing.
