### PR TITLE
Revert "Bump requests from 2.31.0 to 2.32.0"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ pytest-timeout==2.2.0
 pytest-xdist==3.5.0
 python-dotenv==1.0.1
 PyYAML==6.0.1
-requests==2.32.0
+requests==2.31.0
 setuptools==69.0.3
 tenacity==8.2.3
 typeguard==4.1.5


### PR DESCRIPTION
Reverts waku-org/waku-interop-tests#41