### PR TITLE
chore: add peer store capacity

### DIFF
--- a/src/node/waku_node.py
+++ b/src/node/waku_node.py
@@ -118,6 +118,7 @@ class WakuNode:
                 "min-relay-peers-to-publish": "1",
                 "log-level": "DEBUG",
                 "rest-filter-cache-capacity": "50",
+                "peer-store-capacity": "10",
             }
             default_args.update(go_waku_args)
         elif self.is_nwaku():


### PR DESCRIPTION
## PR Details

Now go-waku needs this flag so it can accept direct peer connections
Report with this PR: https://waku-org.github.io/waku-interop-tests/go/186/

## Issues reported:


