### PR TITLE
fix: cluster_id 0 for peer store related tests

### DIFF
--- a/src/env_vars.py
+++ b/src/env_vars.py
@@ -16,8 +16,8 @@ def get_env_var(var_name, default=None):
 # Configuration constants. Need to be upercase to appear in reports
 DEFAULT_NWAKU = "harbor.status.im/wakuorg/nwaku:latest"
 DEFAULT_GOWAKU = "harbor.status.im/wakuorg/go-waku:latest"
-NODE_1 = get_env_var("NODE_1", DEFAULT_GOWAKU)
-NODE_2 = get_env_var("NODE_2", DEFAULT_NWAKU)
+NODE_1 = get_env_var("NODE_1", DEFAULT_NWAKU)
+NODE_2 = get_env_var("NODE_2", DEFAULT_GOWAKU)
 ADDITIONAL_NODES = get_env_var("ADDITIONAL_NODES", f"{DEFAULT_NWAKU},{DEFAULT_GOWAKU},{DEFAULT_NWAKU}")
 # more nodes need to follow the NODE_X pattern
 DOCKER_LOG_DIR = get_env_var("DOCKER_LOG_DIR", "./log/docker")

--- a/src/env_vars.py
+++ b/src/env_vars.py
@@ -16,8 +16,8 @@ def get_env_var(var_name, default=None):
 # Configuration constants. Need to be upercase to appear in reports
 DEFAULT_NWAKU = "harbor.status.im/wakuorg/nwaku:latest"
 DEFAULT_GOWAKU = "harbor.status.im/wakuorg/go-waku:latest"
-NODE_1 = get_env_var("NODE_1", DEFAULT_NWAKU)
-NODE_2 = get_env_var("NODE_2", DEFAULT_GOWAKU)
+NODE_1 = get_env_var("NODE_1", DEFAULT_GOWAKU)
+NODE_2 = get_env_var("NODE_2", DEFAULT_NWAKU)
 ADDITIONAL_NODES = get_env_var("ADDITIONAL_NODES", f"{DEFAULT_NWAKU},{DEFAULT_GOWAKU},{DEFAULT_NWAKU}")
 # more nodes need to follow the NODE_X pattern
 DOCKER_LOG_DIR = get_env_var("DOCKER_LOG_DIR", "./log/docker")

--- a/tests/peer_connection_management/test_peer_store.py
+++ b/tests/peer_connection_management/test_peer_store.py
@@ -16,15 +16,17 @@ class TestPeerStore(StepsRelay, StepsStore):
         self.setup_optional_nodes(cluster_id="0")
         nodes = [self.node1, self.node2]
         nodes.extend(self.optional_nodes)
-        delay(1)
+        delay(10)
         ids = []
-        for node in nodes:
+        for i, node in enumerate(nodes):
             node_id = node.get_id()
+            logger.debug(f"Node {i} peer ID {node_id}")
             ids.append(node_id)
 
         for i in range(5):
             others = []
             for peer_info in nodes[i].get_peers():
+                logger.debug(f"Node {i} peer info {peer_info}")
                 peer_id = peer_info2id(peer_info, nodes[i].is_nwaku())
                 others.append(peer_id)
 

--- a/tests/peer_connection_management/test_peer_store.py
+++ b/tests/peer_connection_management/test_peer_store.py
@@ -11,8 +11,9 @@ logger = get_custom_logger(__name__)
 
 
 class TestPeerStore(StepsRelay, StepsStore):
-    @pytest.mark.usefixtures("setup_main_relay_nodes", "setup_optional_relay_nodes")
     def test_get_peers(self):
+        self.setup_main_nodes(cluster_id="0")
+        self.setup_optional_nodes(cluster_id="0")
         nodes = [self.node1, self.node2]
         nodes.extend(self.optional_nodes)
         delay(1)
@@ -29,8 +30,9 @@ class TestPeerStore(StepsRelay, StepsStore):
 
             assert (i == 0 and len(others) == 4) or (i > 0 and len(others) >= 1), f"Some nodes missing in the peer store of Node ID {ids[i]}"
 
-    @pytest.mark.usefixtures("setup_main_relay_nodes", "setup_optional_relay_nodes")
     def test_add_peers(self):
+        self.setup_main_nodes(cluster_id="0")
+        self.setup_optional_nodes(cluster_id="0")
         nodes = [self.node1, self.node2]
         nodes.extend(self.optional_nodes)
         delay(1)
@@ -58,8 +60,8 @@ class TestPeerStore(StepsRelay, StepsStore):
 
     @pytest.mark.skip(reason="waiting for https://github.com/waku-org/nwaku/issues/1549 resolution")
     def test_get_peers_two_protocols(self):
-        self.setup_first_publishing_node(store="true", relay="true")
-        self.setup_first_store_node(store="true", relay="false")
+        self.setup_first_publishing_node(cluster_id="0", store="true", relay="true")
+        self.setup_first_store_node(cluster_id="0", store="true", relay="false")
         delay(1)
         node1_peers = self.publishing_node1.get_peers()
         node2_peers = self.store_node1.get_peers()
@@ -71,8 +73,8 @@ class TestPeerStore(StepsRelay, StepsStore):
     @pytest.mark.skip(reason="pending on https://github.com/waku-org/nwaku/issues/2792")
     @pytest.mark.skipif("go-waku" in (NODE_1 + NODE_2), reason="Test works only with nwaku")
     def test_use_persistent_storage_survive_restart(self):
-        self.setup_first_relay_node(peer_persistence="true")
-        self.setup_second_relay_node()
+        self.setup_first_relay_node(cluster_id="0", peer_persistence="true")
+        self.setup_second_relay_node(cluster_id="0")
         delay(1)
         node1_peers = self.node1.get_peers()
         node2_peers = self.node2.get_peers()
@@ -92,8 +94,8 @@ class TestPeerStore(StepsRelay, StepsStore):
     @pytest.mark.skip(reason="waiting for https://github.com/waku-org/nwaku/issues/2592 resolution")
     @pytest.mark.skipif("go-waku" in (NODE_1 + NODE_2), reason="Test works only with nwaku")
     def test_peer_store_content_after_node2_restarts(self):
-        self.setup_first_relay_node()
-        self.setup_second_relay_node()
+        self.setup_first_relay_node(cluster_id="0")
+        self.setup_second_relay_node(cluster_id="0")
         delay(1)
         node1_peers = self.node1.get_peers()
         node2_peers = self.node2.get_peers()

--- a/tests/peer_exchange/test_peer_exchange.py
+++ b/tests/peer_exchange/test_peer_exchange.py
@@ -8,13 +8,13 @@ from src.steps.peer_exchange import StepsPeerExchange
 @pytest.mark.skipif("go-waku" not in NODE_2, reason="Test works only with go-waku as responder - https://github.com/waku-org/nwaku/issues/2875")
 class TestPeerExchange(StepsPeerExchange):
     def test_get_peers_for_blank_node(self):
-        self.setup_first_relay_node(relay_peer_exchange="true")
-        self.setup_second_relay_node(peer_exchange="true")
+        self.setup_first_relay_node(cluster_id="0", relay_peer_exchange="true")
+        self.setup_second_relay_node(cluster_id="0", peer_exchange="true")
         delay(1)
         node1_peers = self.node1.get_peers()
         assert len(node1_peers) == 1
         self.responder_multiaddr = peer_info2multiaddr(node1_peers[0], self.node1.is_nwaku())
-        self.setup_third_node_as_peer_exchange_requester(discv5_discovery="false")
+        self.setup_third_node_as_peer_exchange_requester(cluster_id="0", discv5_discovery="false")
 
         others = {self.node1.get_id(), self.node2.get_id()}
 
@@ -26,13 +26,13 @@ class TestPeerExchange(StepsPeerExchange):
         assert own == others, f"Not all nodes found as expected in peer store of Node3"
 
     def test_get_peers_for_filter_node(self):
-        self.setup_first_relay_node(filter="true", relay_peer_exchange="true")
-        self.setup_second_relay_node(filter="true", peer_exchange="true")
+        self.setup_first_relay_node(cluster_id="0", filter="true", relay_peer_exchange="true")
+        self.setup_second_relay_node(cluster_id="0", filter="true", peer_exchange="true")
         delay(1)
         node1_peers = self.node1.get_peers()
         assert len(node1_peers) == 1
         self.responder_multiaddr = peer_info2multiaddr(node1_peers[0], self.node1.is_nwaku())
-        self.setup_third_node_as_peer_exchange_requester(discv5_discovery="false")
+        self.setup_third_node_as_peer_exchange_requester(cluster_id="0", discv5_discovery="false")
 
         suitable_peers = []
         for peer_info in self.node3.get_peers():
@@ -44,8 +44,8 @@ class TestPeerExchange(StepsPeerExchange):
         self.setup_fourth_node_as_filter(filternode=suitable_peers[0])
 
     def test_get_peers_after_node1_was_restarted(self):
-        self.setup_first_relay_node(relay_peer_exchange="true")
-        self.setup_second_relay_node(peer_exchange="true")
+        self.setup_first_relay_node(cluster_id="0", relay_peer_exchange="true")
+        self.setup_second_relay_node(cluster_id="0", peer_exchange="true")
         delay(1)
         node1_peers = self.node1.get_peers()
         assert len(node1_peers) == 1
@@ -57,7 +57,7 @@ class TestPeerExchange(StepsPeerExchange):
         delay(1)
 
         # Start Node3
-        self.setup_third_node_as_peer_exchange_requester(discv5_discovery="false")
+        self.setup_third_node_as_peer_exchange_requester(cluster_id="0", discv5_discovery="false")
         others = {self.node1.get_id(), self.node2.get_id()}
 
         own = set()


### PR DESCRIPTION
## PR Details

Use cluster_id == 0 for go-waku and peer store related tests to compensate for changes related to deprecation of named sharding.

Issues discovered:
- https://github.com/waku-org/go-waku/issues/1162