### PR TITLE
increase ci timeout

### DIFF
--- a/.github/workflows/test_common.yml
+++ b/.github/workflows/test_common.yml
@@ -36,7 +36,7 @@ jobs:
   tests:
     name: tests
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 90
     steps:
 
     - uses: actions/checkout@v4


### PR DESCRIPTION
## PR Details

When a run was reaching 30 mins it was timing out and showed as failed.
Increasing the timeout to fix this issue

## Issues reported:

<!-- Issues found while working for this PR --> 
