### PR TITLE
chore: fix lp test

### DIFF
--- a/src/steps/light_push.py
+++ b/src/steps/light_push.py
@@ -13,6 +13,7 @@ from src.env_vars import (
 from src.node.waku_node import WakuNode
 from src.steps.common import StepsCommon
 from src.test_data import VALID_PUBSUB_TOPICS
+from tenacity import retry, stop_after_delay, wait_fixed
 
 logger = get_custom_logger(__name__)
 
@@ -137,3 +138,9 @@ class StepsLightPush(StepsCommon):
         payload = {"pubsubTopic": pubsub_topic, "message": message}
         payload.update(kwargs)
         return payload
+
+    @allure.step
+    @retry(stop=stop_after_delay(120), wait=wait_fixed(1), reraise=True)
+    def subscribe_and_light_push_with_retry(self):
+        self.subscribe_to_pubsub_topics_via_relay()
+        self.check_light_pushed_message_reaches_receiving_peer()

--- a/tests/light_push/test_publish.py
+++ b/tests/light_push/test_publish.py
@@ -267,9 +267,7 @@ class TestLightPushPublish(StepsLightPush):
         self.check_light_pushed_message_reaches_receiving_peer()
         self.receiving_node1.restart()
         self.receiving_node1.ensure_ready()
-        delay(30)
-        self.subscribe_to_pubsub_topics_via_relay()
-        self.check_light_pushed_message_reaches_receiving_peer()
+        self.subscribe_and_light_push_with_retry()
 
     def test_light_push_and_retrieve_100_messages(self):
         num_messages = 100  # if increase this number make sure to also increase rest-relay-cache-capacity flag


### PR DESCRIPTION
## PR Details

Fixed light-push test that failed intermitently by wrapping the functions that failed in a retry mechanism
Test is [green](https://waku-org.github.io/waku-interop-tests/nim/413/) with this fix

## Issues reported:

<!-- Issues found while working for this PR --> 
