### PR TITLE
Ignore test_store_filter_interaction_with_six_nodes when NODE_2 = go-…

### DIFF
--- a/tests/e2e/test_e2e.py
+++ b/tests/e2e/test_e2e.py
@@ -178,6 +178,7 @@ class TestE2E(StepsFilter, StepsStore, StepsRelay, StepsLightPush):
         # self.node1 relays and we check that self.node10 receives the message
         self.check_published_message_reaches_relay_peer(sender=self.node1, peer_list=[self.node10], message_propagation_delay=1)
 
+    @pytest.mark.skipif("go-waku" in NODE_2, reason="Test works only with nwaku")
     def test_store_filter_interaction_with_six_nodes(self):
         logger.debug("Create  6 nodes")
         self.node4 = WakuNode(NODE_2, f"node3_{self.test_id}")


### PR DESCRIPTION
…waku

## PR Details

<!--
Describe in details the feature or scenario that this PR is automating tests for.
-->
Branch created to ignore test test_store_filter_interaction_with_six_nodes which fails in go-waku case 
## Issues reported:

<!-- Issues found while working for this PR --> 
