### PR TITLE
fix: comment out on chain RLN tests

### DIFF
--- a/tests/relay/test_rln.py
+++ b/tests/relay/test_rln.py
@@ -134,6 +134,7 @@ class TestRelayRLN(StepsRLN, StepsRelay):
                 failed_payloads.append(payload["description"])
             assert not failed_payloads, f"Payloads failed: {failed_payloads}"
 
+    @pytest.mark.skip(reason="Waiting for issue resolution https://github.com/waku-org/nwaku/issues/3208")
     @pytest.mark.timeout(600)
     def test_valid_payloads_dynamic_at_spam_rate(self, pytestconfig):
         message_limit = 100
@@ -159,6 +160,7 @@ class TestRelayRLN(StepsRLN, StepsRelay):
             except Exception as e:
                 assert "RLN validation failed" or "NonceLimitReached" in str(e)
 
+    @pytest.mark.skip(reason="Waiting for issue resolution https://github.com/waku-org/nwaku/issues/3208")
     @pytest.mark.timeout(600)
     def test_valid_payloads_dynamic_at_slow_rate(self, pytestconfig):
         message_limit = 100


### PR DESCRIPTION
## PR Details

Test cases for on chain RLN were commented out to save workflow run time while issue 3208 is open.

Issues discovered:
- https://github.com/waku-org/nwaku/issues/3208
