### PR TITLE
chore: updating the hash-computing function to use hex

### DIFF
--- a/src/libs/common.py
+++ b/src/libs/common.py
@@ -26,6 +26,18 @@ def to_base64(input_data):
     return base64_encoded.decode()
 
 
+def to_hex(input_data):
+    if isinstance(input_data, str):
+        input_bytes = input_data.encode()
+    elif isinstance(input_data, int):
+        input_bytes = str(input_data).encode()
+    elif isinstance(input_data, bytes):
+        input_bytes = input_data
+    else:
+        input_bytes = str(input_data).encode()
+    return "0x" + input_bytes.hex()
+
+
 def attach_allure_file(file):
     logger.debug(f"Attaching file {file}")
     allure.attach.file(file, name=os.path.basename(file), attachment_type=allure.attachment_type.TEXT)

--- a/src/steps/common.py
+++ b/src/steps/common.py
@@ -57,7 +57,7 @@ class StepsCommon:
             ctx.update(base64.b64decode(msg["meta"]))
         ctx.update(int(msg["timestamp"]).to_bytes(8, byteorder="big"))
         hash_bytes = ctx.digest()
-        return base64.b64encode(hash_bytes).decode("utf-8")
+        return "0x" + hash_bytes.hex()
 
     def get_time_list_pass(self):
         ts_pass = [

--- a/tests/store/test_cursor.py
+++ b/tests/store/test_cursor.py
@@ -1,6 +1,6 @@
 import pytest
 from src.env_vars import NODE_1, NODE_2
-from src.libs.common import to_base64
+from src.libs.common import to_base64, to_hex
 from src.node.store_response import StoreResponse
 from src.steps.store import StepsStore
 
@@ -70,8 +70,8 @@ class TestCursor(StepsStore):
     def test_passing_invalid_cursor(self):
         for i in range(4):
             self.publish_message(message=self.create_message(payload=to_base64(f"Message_{i}")))
-        # creating a invalid base64 cursor
-        cursor = to_base64("test")
+        # creating a invalid hex cursor
+        cursor = to_hex("test")
         for node in self.store_nodes:
             store_response = self.get_messages_from_store(node, page_size=100, cursor=cursor)
             assert not store_response.messages, "Messages found"

--- a/tests/store/test_hashes.py
+++ b/tests/store/test_hashes.py
@@ -57,10 +57,10 @@ class TestHashes(StepsStore):
     def test_store_with_non_base64_hash(self):
         for i in range(4):
             self.publish_message(message=self.create_message(payload=to_base64(f"Message_{i}")))
-        non_base64_hash = "test"
+        non_hex_hash = "test"
         for node in self.store_nodes:
             try:
-                store_response = self.get_messages_from_store(node, hashes=non_base64_hash, page_size=50)
+                store_response = self.get_messages_from_store(node, hashes=non_hex_hash, page_size=50)
                 assert not store_response.messages
             except Exception as ex:
                 assert "waku message hash parsing error: invalid hash length" in str(ex)

--- a/tests/store/test_hashes.py
+++ b/tests/store/test_hashes.py
@@ -107,8 +107,8 @@ class TestHashes(StepsStore):
                 assert "waku message hash parsing error" in str(ex), "Unexpected error for combined empty and valid hash"
 
     # Test for hashes that include non-hex characters.
-    def test_store_with_non_base64_characters_in_hash(self):
-        non_hex_hash = "###INVALID HEX###"  # Invalid hash with non-hex characters
+    def test_store_with_non_hex_characters_in_hash(self):
+        non_hex_hash = "### INVALID HASH ###"  # Invalid hash with non-hex characters
         for i in range(4):
             self.publish_message(message=self.create_message(payload=to_base64(f"Message_{i}")))
 

--- a/tests/store/test_hashes.py
+++ b/tests/store/test_hashes.py
@@ -1,6 +1,6 @@
 import pytest
 from src.env_vars import NODE_2
-from src.libs.common import to_base64
+from src.libs.common import to_base64, to_hex
 from src.libs.custom_logger import get_custom_logger
 from src.steps.store import StepsStore
 from src.test_data import SAMPLE_INPUTS
@@ -46,7 +46,7 @@ class TestHashes(StepsStore):
     def test_store_with_invalid_hash(self):
         for i in range(4):
             self.publish_message(message=self.create_message(payload=to_base64(f"Message_{i}")))
-        invalid_hash = to_base64("test")
+        invalid_hash = to_hex("test")
         for node in self.store_nodes:
             try:
                 store_response = self.get_messages_from_store(node, hashes=invalid_hash, page_size=50)

--- a/tests/store/test_hashes.py
+++ b/tests/store/test_hashes.py
@@ -54,7 +54,7 @@ class TestHashes(StepsStore):
             except Exception as ex:
                 assert "waku message hash parsing error: invalid hash length" in str(ex)
 
-    def test_store_with_non_base64_hash(self):
+    def test_store_with_non_hex_hash(self):
         for i in range(4):
             self.publish_message(message=self.create_message(payload=to_base64(f"Message_{i}")))
         non_hex_hash = "test"
@@ -63,7 +63,7 @@ class TestHashes(StepsStore):
                 store_response = self.get_messages_from_store(node, hashes=non_hex_hash, page_size=50)
                 assert not store_response.messages
             except Exception as ex:
-                assert "waku message hash parsing error: invalid hash length" in str(ex)
+                assert "Exception converting hex string to bytes: t is not a hexadecimal character" in str(ex)
 
     # Addon on Test
 
@@ -106,14 +106,14 @@ class TestHashes(StepsStore):
             except Exception as ex:
                 assert "waku message hash parsing error" in str(ex), "Unexpected error for combined empty and valid hash"
 
-    # Test for hashes that include non-Base64 characters.
+    # Test for hashes that include non-hex characters.
     def test_store_with_non_base64_characters_in_hash(self):
-        non_base64_hash = "###INVALID###"  # Invalid hash with non-Base64 characters
+        non_hex_hash = "###INVALID HEX###"  # Invalid hash with non-hex characters
         for i in range(4):
             self.publish_message(message=self.create_message(payload=to_base64(f"Message_{i}")))
 
         for node in self.store_nodes:
-            store_response = self.get_store_messages_with_errors(node, hashes=non_base64_hash, page_size=50)
+            store_response = self.get_store_messages_with_errors(node, hashes=non_hex_hash, page_size=50)
 
             assert (
                 "waku message hash parsing error: Incorrect base64 string" in store_response["error_message"]

--- a/tests/store/test_hashes.py
+++ b/tests/store/test_hashes.py
@@ -116,8 +116,8 @@ class TestHashes(StepsStore):
             store_response = self.get_store_messages_with_errors(node, hashes=non_hex_hash, page_size=50)
 
             assert (
-                "waku message hash parsing error: Incorrect base64 string" in store_response["error_message"]
-            ), f"Expected 'Incorrect base64 string' error, got {store_response['error_message']}"
+                "Exception converting hex string to bytes: # is not a hexadecimal character" in store_response["error_message"]
+            ), f"Expected '# is not a hexadecimal character' error, got {store_response['error_message']}"
 
     # Test when duplicate valid hashes are provided.
     def test_store_with_duplicate_hashes(self):


### PR DESCRIPTION
## PR Details

In https://github.com/waku-org/nwaku/pull/3234 we changed the hash format we use in REST from a base64 url-encoded string representation of a byte array, to a hex string.

Updating the interop tests to use and expect the new hex strings

