### PR TITLE
chore: log millisecond

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -3,8 +3,8 @@ addopts = -s --instafail --tb=short --color=auto
 log_level = DEBUG
 log_cli = True
 log_file = log/test.log
-log_cli_format = %(asctime)s %(name)s %(levelname)s %(message)s 
-log_file_format = %(asctime)s %(name)s %(levelname)s %(message)s 
+log_cli_format = %(asctime)s.%(msecs)03d %(levelname)s [%(name)s] %(message)s
+log_file_format = %(asctime)s.%(msecs)03d %(levelname)s [%(name)s] %(message)s
 timeout = 300
 markers =
     smoke: marks tests as smoke test (deselect with '-m "not smoke"')

--- a/src/libs/custom_logger.py
+++ b/src/libs/custom_logger.py
@@ -21,4 +21,11 @@ def get_custom_logger(name):
     logging.getLogger("docker").setLevel(logging.WARNING)
     logger = logging.getLogger(name)
     logger.addFilter(log_length_filter(max_log_line_length))
+
+    # Define a formatter with millisecond precision
+    ch = logging.StreamHandler()
+    formatter = logging.Formatter("%(asctime)s.%(msecs)03d %(levelname)s [%(name)s] %(message)s", datefmt="%Y-%m-%d %H:%M:%S")
+    ch.setFormatter(formatter)
+    logger.addHandler(ch)
+
     return logger


### PR DESCRIPTION
## PR Details
Simple change to bring more time precision in logs

## Issues reported:

This is interesting because that might help correlate `test.log` against `node_1...`.log, etc
