### PR TITLE
chore: waku_message.py rename rateLimitProof to proof

### DIFF
--- a/src/node/waku_message.py
+++ b/src/node/waku_message.py
@@ -13,7 +13,7 @@ class MessageRpcResponse:
     timestamp: Optional[int]
     ephemeral: Optional[bool]
     meta: Optional[str]
-    rateLimitProof: Optional[str] = field(default_factory=dict)
+    proof: Optional[str] = field(default_factory=dict)
     rate_limit_proof: Optional[dict] = field(default_factory=dict)
 
 


### PR DESCRIPTION
## PR Details
This rename is needed because the REST responses from nwaku may contain the proof field


## Issues reported:

This is needed to avoid `waku-interop-tests` failures due to the following enhancement in nwaku: https://github.com/waku-org/nwaku/pull/3286
