### PR TITLE
chore: Not found response is expected when node is not subscribed

### DIFF
--- a/src/steps/sharding.py
+++ b/src/steps/sharding.py
@@ -204,4 +204,4 @@ class StepsSharding(StepsRelay):
             self.check_published_message_reaches_relay_peer(pubsub_topic=pubsub_topic)
             raise AssertionError("Publishing messages on unsubscribed shard worked!!!")
         except Exception as ex:
-            assert f"Failed to publish: Node not subscribed to topic: {pubsub_topic}" in str(ex)
+            assert "Not Found" in str(ex), "Expected 404 Not Found because the node is not subscribed"


### PR DESCRIPTION
## PR Details

nwaku got a bug introduced by the following PR: https://github.com/waku-org/nwaku/pull/3396
That bug made the `unsibscribe` function to not operate properly in waku node. In other words, after performing the unsubscribe, the waku node still got messages from the previous "unsibscribed" topic.

The fix to the above nwaku bug will be suggested in the following PR: https://github.com/waku-org/nwaku/pull/3422
In there, the `unsubscribe` operation is simplified. Nevertheless, once this bug is fixed, we need to adapt the `waku-interop-tests` because if the node is not subscribed to a certain topic, then the REST relay operation will return a 404 (Not found.) And therefore, this PR is to adapt `waku-interop-tests` to this new response.
 
----

special kudos to @AYAHASSAN287 for raising the hand re this issue!
This is another example that `waku-interop-tests` are super supr useful for us. Thanks to all :partying_face: 
