### PR TITLE
chore: adapt tests to nwaku health service refactor

### DIFF
--- a/src/node/waku_node.py
+++ b/src/node/waku_node.py
@@ -262,12 +262,12 @@ class WakuNode:
             except Exception as ex:
                 raise AttributeError(f"Unknown health response format {ex}")
 
-            if self.health_response.get("nodeHealth") != "Ready":
-                raise AssertionError("Waiting for the node health status: Ready")
+            if self.health_response.get("nodeHealth") != "READY":
+                raise AssertionError("Waiting for the node health status: READY")
 
             # for p in self.health_response.get("protocolsHealth"):
-            #     if p.get("Rln Relay") != "Ready":
-            #         raise AssertionError("Waiting for the Rln relay status: Ready")
+            #     if p.get("Rln Relay") != "READY":
+            #         raise AssertionError("Waiting for the Rln relay status: READY")
 
             logger.info("Node protocols are initialized !!")
 


### PR DESCRIPTION
## PR Details

This PR is needed to adapt the tests to the new health check result returned by wakunode2 app.

See:

- https://github.com/waku-org/nwaku/pull/3456

( cc @NagyZoltanPeter @gabrielmer @darshankabariya )