### PR TITLE
 S18/S25/S29 added

### DIFF
--- a/tests/wrappers_tests/test_send_lightpush_and_edge.py
+++ b/tests/wrappers_tests/test_send_lightpush_and_edge.py
@@ -737,3 +737,275 @@ class TestS26LightpushPeerChurn(StepsCommon):
                     assert error_event is None, f"Unexpected message_error event during peer churn: {error_event}"
 
                     assert_event_invariants(sender_collector, request_id)
+
+
+class TestS18StagedTopologyReformation(StepsCommon):
+    """
+    S18: relay absent at T0, lightpush absent at T0, both appear in stages.
+
+    The sender has relay and lightpush enabled but starts fully isolated:
+    no relay peers and no lightpush peers. send() is called before any
+    peer exists. Peers then appear one stage at a time. The message must
+    succeed as soon as any valid path becomes available.
+
+    Two orderings are covered, one per test method:
+      - lightpush appears first, then relay.
+      - relay appears first, then lightpush.
+
+    Both prove the send service recovers from arbitrary staged topology
+    reformation.
+
+    Common topology per stage:
+      [Sender]        relay=True, lightpush=True, isolated at T0.
+      [LightpushPeer] relay=True, lightpush=True, staticnodes=[sender].
+      [RelayPeer]     relay=True, staticnodes=[sender].
+    """
+
+    # Common config shared by the sender and both staged peers.
+    _COMMON = {
+        "relay": True,
+        "lightpush": True,
+        "store": False,
+        "filter": False,
+        "discv5Discovery": False,
+        "numShardsInNetwork": 1,
+    }
+
+    def test_s18_lightpush_first_then_relay(self, node_config):
+        """Sender isolated at T0; lightpush peer appears, then relay peer."""
+        sender_collector = EventCollector()
+
+        node_config.update(self._COMMON)
+
+        sender_result = WrapperManager.create_and_start(
+            config=node_config,
+            event_cb=sender_collector.event_callback,
+        )
+        assert sender_result.is_ok(), f"Failed to start sender: {sender_result.err()}"
+
+        with sender_result.ok_value as sender:
+            # send() before any peer exists must still return Ok(RequestId).
+            message = create_message_bindings(
+                payload=to_base64("S18 lightpush-first staged recovery"),
+                contentTopic="/test/1/s18-lightpush-first/proto",
+            )
+            send_result = sender.send_message(message=message)
+            assert send_result.is_ok(), f"send() must return Ok(RequestId) while isolated, got: {send_result.err()}"
+
+            request_id = send_result.ok_value
+            assert request_id, "send() returned an empty RequestId"
+
+            # No peers yet: the message must not propagate.
+            delay(SERVICE_DOWN_SETTLE_S)
+            early_propagated = wait_for_propagated(sender_collector, request_id, timeout_s=0)
+            assert early_propagated is None, f"message_propagated arrived before any peer joined: {early_propagated}"
+
+            # Stage 1: lightpush peer appears.
+            lightpush_config = {
+                **node_config,
+                "staticnodes": [get_node_multiaddr(sender)],
+                "portsShift": 1,
+            }
+            lightpush_result = WrapperManager.create_and_start(config=lightpush_config)
+            assert lightpush_result.is_ok(), f"Failed to start lightpush peer: {lightpush_result.err()}"
+
+            with lightpush_result.ok_value:
+                # Stage 2: relay peer appears.
+                relay_config = {
+                    **node_config,
+                    "lightpush": False,
+                    "staticnodes": [get_node_multiaddr(sender)],
+                    "portsShift": 2,
+                }
+                relay_result = WrapperManager.create_and_start(config=relay_config)
+                assert relay_result.is_ok(), f"Failed to start relay peer: {relay_result.err()}"
+
+                with relay_result.ok_value:
+                    # The message must succeed once any valid path is available.
+                    propagated = wait_for_propagated(
+                        collector=sender_collector,
+                        request_id=request_id,
+                        timeout_s=RECOVERY_TIMEOUT_S,
+                    )
+                    assert propagated is not None, (
+                        f"No message_propagated within {RECOVERY_TIMEOUT_S}s "
+                        f"after peers appeared in stages. "
+                        f"Collected events: {sender_collector.events}"
+                    )
+                    assert propagated["requestId"] == request_id
+
+                    error = wait_for_error(sender_collector, request_id, timeout_s=0)
+                    assert error is None, f"Unexpected message_error after staged recovery: {error}"
+
+                    assert_event_invariants(sender_collector, request_id)
+
+    def test_s18_relay_first_then_lightpush(self, node_config):
+        """Sender isolated at T0; relay peer appears, then lightpush peer."""
+        sender_collector = EventCollector()
+
+        node_config.update(self._COMMON)
+
+        sender_result = WrapperManager.create_and_start(
+            config=node_config,
+            event_cb=sender_collector.event_callback,
+        )
+        assert sender_result.is_ok(), f"Failed to start sender: {sender_result.err()}"
+
+        with sender_result.ok_value as sender:
+            # send() before any peer exists must still return Ok(RequestId).
+            message = create_message_bindings(
+                payload=to_base64("S18 relay-first staged recovery"),
+                contentTopic="/test/1/s18-relay-first/proto",
+            )
+            send_result = sender.send_message(message=message)
+            assert send_result.is_ok(), f"send() must return Ok(RequestId) while isolated, got: {send_result.err()}"
+
+            request_id = send_result.ok_value
+            assert request_id, "send() returned an empty RequestId"
+
+            # No peers yet: the message must not propagate.
+            delay(SERVICE_DOWN_SETTLE_S)
+            early_propagated = wait_for_propagated(sender_collector, request_id, timeout_s=0)
+            assert early_propagated is None, f"message_propagated arrived before any peer joined: {early_propagated}"
+
+            # Stage 1: relay peer appears.
+            relay_config = {
+                **node_config,
+                "lightpush": False,
+                "staticnodes": [get_node_multiaddr(sender)],
+                "portsShift": 1,
+            }
+            relay_result = WrapperManager.create_and_start(config=relay_config)
+            assert relay_result.is_ok(), f"Failed to start relay peer: {relay_result.err()}"
+
+            with relay_result.ok_value:
+                # Stage 2: lightpush peer appears.
+                lightpush_config = {
+                    **node_config,
+                    "staticnodes": [get_node_multiaddr(sender)],
+                    "portsShift": 2,
+                }
+                lightpush_result = WrapperManager.create_and_start(config=lightpush_config)
+                assert lightpush_result.is_ok(), f"Failed to start lightpush peer: {lightpush_result.err()}"
+
+                with lightpush_result.ok_value:
+                    # The message must succeed once any valid path is available.
+                    propagated = wait_for_propagated(
+                        collector=sender_collector,
+                        request_id=request_id,
+                        timeout_s=RECOVERY_TIMEOUT_S,
+                    )
+                    assert propagated is not None, (
+                        f"No message_propagated within {RECOVERY_TIMEOUT_S}s "
+                        f"after peers appeared in stages. "
+                        f"Collected events: {sender_collector.events}"
+                    )
+                    assert propagated["requestId"] == request_id
+
+                    error = wait_for_error(sender_collector, request_id, timeout_s=0)
+                    assert error is None, f"Unexpected message_error after staged recovery: {error}"
+
+                    assert_event_invariants(sender_collector, request_id)
+
+
+class TestS25EphemeralLightpushWithStore(StepsCommon):
+    """
+    S25 — Ephemeral message over lightpush with a reachable store peer.
+
+    The sender is an Edge node, so it has no local relay and publishes only
+    via lightpush. A docker store peer is reachable and joined to the
+    lightpush peer's relay mesh, so the message does reach a store.
+
+    Because ephemeral messages are never store-validated, the expected result
+    is Propagated only — no Sent — even though the store peer is reachable.
+    This is the lightpush-transport counterpart of S24 and proves the
+    ephemeral rule is transport-independent.
+
+    Topology mirrors S11:
+      [LightpushPeer] wrapper, relay=True, lightpush=True, store=False
+      [StorePeer]     docker WakuNode, relay=true, store=true, joined to
+                      the lightpush peer's shard-0 relay mesh
+      [Edge]          wrapper, mode="Edge", reliabilityEnabled=True,
+                      staticnodes=[lightpush_peer, store_peer]
+    """
+
+    def test_s25_ephemeral_lightpush_with_store(self):
+        sender_collector = EventCollector()
+
+        common = {
+            "numShardsInNetwork": 1,
+        }
+
+        lightpush_config = build_node_config(
+            relay=True,
+            lightpush=True,
+            **common,
+        )
+
+        lightpush_result = WrapperManager.create_and_start(config=lightpush_config)
+        assert lightpush_result.is_ok(), f"Failed to start lightpush peer: {lightpush_result.err()}"
+
+        with lightpush_result.ok_value as lightpush_peer:
+            lightpush_multiaddr = get_node_multiaddr(lightpush_peer)
+
+            # Docker store peer joined to the lightpush peer's shard-0 relay
+            # mesh, so messages propagated by the lightpush peer are archived.
+            store_peer = WakuNode(NODE_1, f"s25_store_{self.test_id}")
+            store_peer.start(relay="true", store="true")
+            self.add_node_peer(store_peer, [lightpush_multiaddr])
+            store_peer.set_relay_subscriptions([STORE_PEER_PUBSUB_TOPIC])
+            store_multiaddr = store_peer.get_multiaddr_with_id()
+
+            edge_config = build_node_config(
+                mode="Edge",
+                staticnodes=[lightpush_multiaddr, store_multiaddr],
+                **common,
+            )
+
+            edge_result = WrapperManager.create_and_start(
+                config=edge_config,
+                event_cb=sender_collector.event_callback,
+            )
+            assert edge_result.is_ok(), f"Failed to start edge sender: {edge_result.err()}"
+
+            with edge_result.ok_value as edge_sender:
+                message = create_message_bindings(
+                    payload=to_base64("S25 ephemeral lightpush + store payload"),
+                    contentTopic="/test/1/s25-ephemeral-lightpush/proto",
+                    ephemeral=True,
+                )
+
+                send_result = edge_sender.send_message(message=message)
+                assert send_result.is_ok(), f"send() failed: {send_result.err()}"
+
+                request_id = send_result.ok_value
+                assert request_id, "send() returned an empty RequestId"
+
+                propagated = wait_for_propagated(
+                    collector=sender_collector,
+                    request_id=request_id,
+                    timeout_s=PROPAGATED_TIMEOUT_S,
+                )
+                assert propagated is not None, (
+                    f"No message_propagated event within {PROPAGATED_TIMEOUT_S}s. " f"Collected events: {sender_collector.events}"
+                )
+                assert propagated["requestId"] == request_id
+
+                # Ephemeral messages are never store-validated, so no Sent
+                # event must arrive even though the store peer is reachable.
+                sent = wait_for_sent(
+                    collector=sender_collector,
+                    request_id=request_id,
+                    timeout_s=NO_SENT_OBSERVATION_S,
+                )
+                assert sent is None, (
+                    f"Unexpected message_sent event for an ephemeral message. "
+                    f"Ephemeral messages must never be store-validated.\n"
+                    f"Sent event: {sent}\n"
+                    f"Collected events: {sender_collector.events}"
+                )
+
+                error = wait_for_error(sender_collector, request_id, timeout_s=0)
+                assert error is None, f"Unexpected message_error event: {error}"
+
+                assert_event_invariants(sender_collector, request_id)

--- a/tests/wrappers_tests/test_send_relay_propagation.py
+++ b/tests/wrappers_tests/test_send_relay_propagation.py
@@ -16,6 +16,7 @@ from src.node.wrapper_helpers import (
     wait_for_sent,
     wait_for_error,
 )
+from src.test_data import CONTENT_TOPICS_DIFFERENT_SHARDS
 from tests.wrappers_tests.conftest import free_port
 
 logger = get_custom_logger(__name__)
@@ -706,3 +707,104 @@ class TestS24EphemeralMessageWithReachableStore(StepsCommon):
                 )
 
                 assert_event_invariants(sender_collector, request_id)
+
+
+class TestS29SendOnTopicsMappingToDifferentShards(StepsCommon):
+    """
+    S29 — Send on two different content topics that map to different shards.
+    Sender has a relay peer reachable on shard X and shard Y; topic A maps to
+    shard X and topic B maps to shard Y. Two independent sends, one per topic.
+    Expected: both sends return Ok(RequestId), and each request gets its own
+    message_propagated event following the availability of its own shard.
+    Purpose: ensures shard derivation and delivery behavior are topic-specific.
+    """
+
+    # Topic A -> shard 0, Topic B -> shard 1 (per CONTENT_TOPICS_DIFFERENT_SHARDS).
+    TOPIC_A = CONTENT_TOPICS_DIFFERENT_SHARDS[0]
+    TOPIC_B = CONTENT_TOPICS_DIFFERENT_SHARDS[1]
+
+    def test_s29_send_on_topics_mapping_to_different_shards(self, node_config):
+        sender_collector = EventCollector()
+
+        # numShardsInNetwork=8 so the two topics resolve to distinct shards
+        # (shard 0 and shard 1) instead of being collapsed onto shard 0.
+        node_config.update(
+            {
+                "relay": True,
+                "store": False,
+                "lightpush": False,
+                "filter": False,
+                "discv5Discovery": False,
+                "numShardsInNetwork": 8,
+                "reliabilityEnabled": True,
+            }
+        )
+
+        sender_result = WrapperManager.create_and_start(
+            config=node_config,
+            event_cb=sender_collector.event_callback,
+        )
+        assert sender_result.is_ok(), f"Failed to start sender: {sender_result.err()}"
+
+        with sender_result.ok_value as sender:
+            peer_config = {
+                **node_config,
+                "staticnodes": [get_node_multiaddr(sender)],
+                "portsShift": 1,
+            }
+
+            peer_result = WrapperManager.create_and_start(config=peer_config)
+            assert peer_result.is_ok(), f"Failed to start relay peer: {peer_result.err()}"
+
+            with peer_result.ok_value:
+                assert wait_for_connected(sender_collector) is not None, "Sender did not reach Connected/PartiallyConnected state"
+
+                message_a = create_message_bindings(
+                    payload=to_base64("S29 shard X payload"),
+                    contentTopic=self.TOPIC_A,
+                )
+                send_a = sender.send_message(message=message_a)
+                assert send_a.is_ok(), f"send() on TOPIC_A failed: {send_a.err()}"
+                request_id_a = send_a.ok_value
+                assert request_id_a, "send() on TOPIC_A returned an empty RequestId"
+
+                # Send on topic B (shard Y).
+                message_b = create_message_bindings(
+                    payload=to_base64("S29 shard Y payload"),
+                    contentTopic=self.TOPIC_B,
+                )
+                send_b = sender.send_message(message=message_b)
+                assert send_b.is_ok(), f"send() on TOPIC_B failed: {send_b.err()}"
+                request_id_b = send_b.ok_value
+                assert request_id_b, "send() on TOPIC_B returned an empty RequestId"
+
+                assert request_id_a != request_id_b, "Each send must produce a distinct RequestId"
+
+                # Each request propagates over its own shard's mesh independently.
+                propagated_a = wait_for_propagated(
+                    collector=sender_collector,
+                    request_id=request_id_a,
+                    timeout_s=PROPAGATED_TIMEOUT_S,
+                )
+                assert propagated_a is not None, (
+                    f"No message_propagated event for TOPIC_A within {PROPAGATED_TIMEOUT_S}s. " f"Collected events: {sender_collector.events}"
+                )
+                assert propagated_a["requestId"] == request_id_a
+
+                propagated_b = wait_for_propagated(
+                    collector=sender_collector,
+                    request_id=request_id_b,
+                    timeout_s=PROPAGATED_TIMEOUT_S,
+                )
+                assert propagated_b is not None, (
+                    f"No message_propagated event for TOPIC_B within {PROPAGATED_TIMEOUT_S}s. " f"Collected events: {sender_collector.events}"
+                )
+                assert propagated_b["requestId"] == request_id_b
+
+                # No cross-talk: neither request should produce an error.
+                for request_id in (request_id_a, request_id_b):
+                    error = wait_for_error(sender_collector, request_id, timeout_s=0)
+                    assert error is None, f"Unexpected message_error event for {request_id}: {error}"
+
+                assert_event_invariants(sender_collector, request_id_a)
+                assert_event_invariants(sender_collector, request_id_b)


### PR DESCRIPTION
## Summary

Adds three new E2E scenarios for the send service: **S18**, **S25**, and **S29**.

## What's added

- **S18 — Staged topology reformation** (`test_send_lightpush_and_edge.py`)
  Sender starts isolated, `send()` is called before any peer exists, then peers appear one stage at a time. Two methods cover both orderings (lightpush-first and relay-first).

- **S25 — Ephemeral lightpush with reachable store** (`test_send_lightpush_and_edge.py`)
  Edge sender publishes an ephemeral message via lightpush with a reachable store peer. Expected: `Propagated` only, no `Sent` (lightpush counterpart of S24).

- **S29 — Send on topics mapping to different shards** (`test_send_relay_propagation.py`)
  Two sends on topics resolving to distinct shards (`numShardsInNetwork=8`). Each must return its own `RequestId` and its own `message_propagated` event.

## Scenarios not covered

- **S27** and **S29 (full variant)** are not possible to simulate in the current test environment.

## related CI [job](https://github.com/logos-messaging/logos-delivery-interop-tests/actions/runs/26165507770)