### PR TITLE
fix: Enable RLN registration for fleet tests

### DIFF
--- a/.github/workflows/fleet_tests.yml
+++ b/.github/workflows/fleet_tests.yml
@@ -13,25 +13,25 @@ on:
         required: true
         description: "Node that usually publishes messages. Used for all tests"
         type: string
-        default: "wakuorg/nwaku:latest"
+        default: "wakuorg/nwaku:v0.38.1"
       node2:
         required: true
         description: "Node that usually queries for published messages. Used for all tests"
         type: string
-        default: "wakuorg/nwaku:latest"
+        default: "wakuorg/nwaku:v0.38.1"
       additional_nodes:
         required: false
         description: "Additional optional nodes used in e2e tests, separated by ,"
         type: string
-        default: "wakuorg/nwaku:latest,wakuorg/nwaku:latest,wakuorg/nwaku:latest"
+        default: "wakuorg/nwaku:v0.38.1,wakuorg/nwaku:v0.38.1,wakuorg/nwaku:v0.38.1"
 
 jobs:
   test-common:
     uses: ./.github/workflows/test_common.yml
     secrets: inherit
     with:
-      node1: ${{ inputs.node1 || 'wakuorg/nwaku:latest' }}
-      node2: ${{ inputs.node2 || 'wakuorg/nwaku:latest' }}
-      additional_nodes: ${{ inputs.additional_nodes || 'wakuorg/nwaku:latest,wakuorg/nwaku:latest,wakuorg/nwaku:latest' }}
+      node1: ${{ inputs.node1 || 'wakuorg/nwaku:v0.38.1' }}
+      node2: ${{ inputs.node2 || 'wakuorg/nwaku:v0.38.1' }}
+      additional_nodes: ${{ inputs.additional_nodes || 'wakuorg/nwaku:v0.38.1,wakuorg/nwaku:v0.38.1,wakuorg/nwaku:v0.38.1' }}
       fleet_tests: true
       caller: "fleet"

--- a/src/steps/rln.py
+++ b/src/steps/rln.py
@@ -8,7 +8,7 @@ import allure
 
 from src.steps.common import StepsCommon
 from src.test_data import PUBSUB_TOPICS_RLN
-from src.env_vars import DEFAULT_NWAKU, RLN_CREDENTIALS, NODE_1, NODE_2, ADDITIONAL_NODES
+from src.env_vars import RLN_CREDENTIALS, NODE_1, NODE_2, ADDITIONAL_NODES
 from src.libs.common import gen_step_id, delay
 from src.libs.custom_logger import get_custom_logger
 from src.node.waku_node import WakuNode, rln_credential_store_ready
@@ -135,7 +135,7 @@ class StepsRLN(StepsCommon):
     @allure.step
     def register_rln_single_node(self, prefix="", **kwargs):
         logger.debug("Registering RLN credentials for single node")
-        self.node = WakuNode(DEFAULT_NWAKU, f"node_{gen_step_id()}")
+        self.node = WakuNode(NODE_1, f"node_{gen_step_id()}")
         return self.node.register_rln(rln_keystore_prefix=prefix, rln_creds_source=kwargs["rln_creds_source"], rln_creds_id=kwargs["rln_creds_id"])
 
     @allure.step

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,7 +50,7 @@ def fleet_rln_state(request):
         return
 
     from src.node.waku_node import WakuNode
-    from src.env_vars import RLN_CREDENTIALS, DEFAULT_NWAKU
+    from src.env_vars import RLN_CREDENTIALS, NODE_1
 
     if not RLN_CREDENTIALS:
         logger.info("Fleet RLN: RLN_CREDENTIALS not set – nodes will start without RLN")
@@ -61,7 +61,7 @@ def fleet_rln_state(request):
     try:
         for i in range(2):
             prefix = "".join(random.choices(string.ascii_lowercase, k=4))
-            node = WakuNode(DEFAULT_NWAKU, f"rln_reg_{i + 1}_{gen_step_id()}")
+            node = WakuNode(NODE_1, f"rln_reg_{i + 1}_{gen_step_id()}")
             membership_index = node.register_rln(
                 rln_keystore_prefix=prefix,
                 rln_creds_source=RLN_CREDENTIALS,


### PR DESCRIPTION
## PR Details

Set Waku Fleet Tests workflow to use v0.38.1 image to enable RLN registration. Related to https://github.com/logos-messaging/logos-delivery/issues/3846

## Passing workflow
https://github.com/logos-messaging/logos-delivery-interop-tests/actions/runs/26137632264/job/76876145483