### PR TITLE
chore: Change fleet tests to run once a week

### DIFF
--- a/.github/workflows/fleet_tests.yml
+++ b/.github/workflows/fleet_tests.yml
@@ -6,7 +6,7 @@ concurrency:
 
 on:
   schedule:
-    - cron: '0 2 * * *'
+    - cron: '0 2 * * 0'
   workflow_dispatch:
     inputs:
       node1:


### PR DESCRIPTION
## PR Details

Set Waku Fleet Tests workflow schedule to run once a week. Low frequency of changes is expected to happen to Waku test fleet due to transition to Logos fleet.