### PR TITLE
ci: port Nim checksum fix to test_common.yml

### DIFF
--- a/.github/workflows/test_common.yml
+++ b/.github/workflows/test_common.yml
@@ -117,6 +117,10 @@ jobs:
           echo "$HOME/.nimble/bin" >> "$GITHUB_PATH"
           export PATH="$HOME/.nimble/bin:$PATH"
           choosenim 2.2.4
+          # Pin the nimble that generated logos-delivery's nimble.lock. A newer
+          # nimble recomputes the locked Nim package checksum differently, which
+          # makes `nimble setup --localdeps` abort with a checksum mismatch.
+          (cd /tmp && nimble install "nimble@0.22.3" -y)
           nim --version
           nimble --version
 
@@ -137,13 +141,10 @@ jobs:
 
           ln -sf waku.nimble waku.nims
 
-          # install Nim deps
-          nimble install -y
-
-          # do the real setup, do not fake .nimble-setup
-          make setup
-
-          # now build the shared library
+          # `make liblogosdelivery` resolves the locked deps via
+          # `nimble setup --localdeps` (build-deps prerequisite); a bare
+          # `nimble install -y` here is redundant and pulls Nim from the lock,
+          # which is what triggered the checksum mismatch.
           make liblogosdelivery
 
           SO_PATH="$(find . -type f -name 'liblogosdelivery.so' | head -n 1)"


### PR DESCRIPTION
## Problem

The scheduled **"master Nim → Nim Waku Interop Tests"** job ([example run](https://github.com/logos-messaging/logos-delivery-interop-tests/actions/runs/26997274396)) fails at *Build liblogosdelivery.so for python bindings* with:

```
Error: Downloaded package checksum does not correspond to that in the lock file:
   Package:           nim@v.2.2.4@r.911e0dbb1f76de61fa0215ab1bb85af5334cc9a8
   Checksum:          a092a045d3a427d127a5334a6e59c76faff54686
   Expected checksum: 68bb85cbfb1832ce4db43943911b046c3af3caab
```

PR #188 already fixed this class of failure, but only in `pr_tests.yml`. The scheduled run is driven by `test_common.yml`, which #188 never touched — so the daily job keeps failing on the same bug.

## Fix

Port the two #188 changes into `test_common.yml`:

1. **Pin nimble.** The "Install Nim 2.2.4" step ran `choosenim 2.2.4` and stopped, so it picked up choosenim's latest nimble, which recomputes the locked Nim package checksum differently. Add the `nimble@0.22.3` pin (the nimble that generated logos-delivery's `nimble.lock`).
2. **Drop the bare `nimble install -y`** (and `make setup`), which pulled Nim from the lock and triggered the checksum check. Rely on `make liblogosdelivery`, whose `nimble setup --localdeps` prerequisite resolves the locked deps correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)