### PR TITLE
ignore the node version test

### DIFF
--- a/tests/metrics/test_metrics.py
+++ b/tests/metrics/test_metrics.py
@@ -10,6 +10,7 @@ from src.steps.store import StepsStore
 
 
 class TestMetrics(StepsRelay, StepsMetrics, StepsFilter, StepsLightPush, StepsStore):
+    @pytest.mark.xfail(reason="these metrics are new from libp2p and has no values yet")
     def test_metrics_initial_value(self):
         node = WakuNode(DEFAULT_NWAKU, f"node1_{self.test_id}")
         node.start(relay="true", filter="true", store="true", lightpush="true")

--- a/tests/rest_flags/test_debug_flags.py
+++ b/tests/rest_flags/test_debug_flags.py
@@ -21,6 +21,7 @@ class TestDebugFlags(StepsFilter, StepsStore, StepsRelay, StepsLightPush):
     def nodes(self):
         self.node1 = WakuNode(NODE_2, f"node1_{self.test_id}")
 
+    @pytest.mark.skip(reason="Volatile: asserts a specific node version range that changes frequently across releases")
     def test_verify_node_version2(self):
         self.node1.start(relay="true")
         node1_version = self.node1.get_version()


### PR DESCRIPTION
## PR Details

<!--
Describe in details the feature or scenario that this PR is automating tests for.
-->

This PR to skip/xfail two tests fail on CI daily 

- test_verify_node_version2 : the version change always and matching the version to specific one isn't reliable , if the node version in the future will be less changable we can bring it back 
- test_metrics_initial_value: these values coming from nimlibp2p and have no values assigned yet so all set to 0 ( might be reenabled soon that's why not deleted )