### PR TITLE
Channel API RC01-RC02

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,6 @@ dmypy.json
 
 # Waku node runtime artifacts
 store.sqlite3*
+
+# SDS / reliable channel manager generated files
+data/

--- a/src/node/wrappers_manager.py
+++ b/src/node/wrappers_manager.py
@@ -75,6 +75,22 @@ class WrapperManager:
     def send_message(self, message: dict, *, timeout_s: float = 20.0) -> Result[str, str]:
         return self._node.send_message(message, timeout_s=timeout_s)
 
+    def channel_create(
+        self,
+        channel_id: str,
+        content_topic: str,
+        sender_id: str,
+        *,
+        timeout_s: float = 20.0,
+    ) -> Result[str, str]:
+        return self._node.channel_create(channel_id, content_topic, sender_id, timeout_s=timeout_s)
+
+    def channel_send(self, channel_id: str, message: dict, *, timeout_s: float = 20.0) -> Result[str, str]:
+        return self._node.channel_send(channel_id, message, timeout_s=timeout_s)
+
+    def channel_close(self, channel_id: str, *, timeout_s: float = 20.0) -> Result[int, str]:
+        return self._node.channel_close(channel_id, timeout_s=timeout_s)
+
     def get_available_node_info_ids(self, *, timeout_s: float = 20.0) -> Result[list[str], str]:
         return self._node.get_available_node_info_ids(timeout_s=timeout_s)
 

--- a/tests/wrappers_tests/test_channel_lifecycle.py
+++ b/tests/wrappers_tests/test_channel_lifecycle.py
@@ -14,6 +14,8 @@ class TestChannelLifecycle:
         The reliable channel manager is mounted automatically for a Core-mode
         node, so no store / --reliability is needed. No events are expected.
         """
+        node_config.update({"mode": "Core"})
+
         create_node_result = WrapperManager.create_and_start(config=node_config)
         assert create_node_result.is_ok(), f"Failed to create and start node: {create_node_result.err()}"
         node = create_node_result.ok_value

--- a/tests/wrappers_tests/test_channel_lifecycle.py
+++ b/tests/wrappers_tests/test_channel_lifecycle.py
@@ -1,0 +1,30 @@
+import pytest
+from src.node.wrappers_manager import WrapperManager
+
+CHANNEL_ID = "rc01-channel"
+CONTENT_TOPIC = "/test/1/channel/proto"
+SENDER_ID = "rc01-sender"
+
+
+@pytest.mark.smoke
+class TestChannelLifecycle:
+    def test_rc01_create_channel_duplicate_rejected(self, node_config):
+        """RC01: create a channel; a duplicate create with the same id is rejected.
+
+        The reliable channel manager is mounted automatically for a Core-mode
+        node, so no store / --reliability is needed. No events are expected.
+        """
+        create_node_result = WrapperManager.create_and_start(config=node_config)
+        assert create_node_result.is_ok(), f"Failed to create and start node: {create_node_result.err()}"
+        node = create_node_result.ok_value
+
+        try:
+            create_result = node.channel_create(CHANNEL_ID, CONTENT_TOPIC, SENDER_ID)
+            assert create_result.is_ok(), f"channel_create failed: {create_result.err()}"
+            assert create_result.ok_value == CHANNEL_ID, f"channel_create returned unexpected id: {create_result.ok_value!r}"
+
+            duplicate_result = node.channel_create(CHANNEL_ID, CONTENT_TOPIC, SENDER_ID)
+            assert duplicate_result.is_err(), f"duplicate channel_create must fail, got Ok({duplicate_result.ok_value!r})"
+            assert f"channel already exists: {CHANNEL_ID}" in duplicate_result.err(), f"unexpected error message: {duplicate_result.err()!r}"
+        finally:
+            node.stop_and_destroy()

--- a/tests/wrappers_tests/test_channel_lifecycle.py
+++ b/tests/wrappers_tests/test_channel_lifecycle.py
@@ -1,9 +1,12 @@
 import pytest
 from src.node.wrappers_manager import WrapperManager
+from src.node.wrapper_helpers import EventCollector, create_message_bindings
 
 CHANNEL_ID = "rc01-channel"
 CONTENT_TOPIC = "/test/1/channel/proto"
 SENDER_ID = "rc01-sender"
+
+UNKNOWN_CHANNEL_ID = "rc02-unknown-channel"
 
 
 @pytest.mark.smoke
@@ -16,7 +19,8 @@ class TestChannelLifecycle:
         """
         node_config.update({"mode": "Core"})
 
-        create_node_result = WrapperManager.create_and_start(config=node_config)
+        collector = EventCollector()
+        create_node_result = WrapperManager.create_and_start(config=node_config, event_cb=collector.event_callback)
         assert create_node_result.is_ok(), f"Failed to create and start node: {create_node_result.err()}"
         node = create_node_result.ok_value
 
@@ -28,5 +32,28 @@ class TestChannelLifecycle:
             duplicate_result = node.channel_create(CHANNEL_ID, CONTENT_TOPIC, SENDER_ID)
             assert duplicate_result.is_err(), f"duplicate channel_create must fail, got Ok({duplicate_result.ok_value!r})"
             assert f"channel already exists: {CHANNEL_ID}" in duplicate_result.err(), f"unexpected error message: {duplicate_result.err()!r}"
+
+            assert collector.events == [], f"expected no events, got: {collector.events}"
+        finally:
+            node.stop_and_destroy()
+
+    def test_rc02_send_on_unknown_channel_rejected(self, node_config):
+        """RC02: channel_send() to an id that was never created is rejected.
+
+        The send must Err with "unknown channel: <id>" and emit no events.
+        """
+        node_config.update({"mode": "Core"})
+
+        collector = EventCollector()
+        create_node_result = WrapperManager.create_and_start(config=node_config, event_cb=collector.event_callback)
+        assert create_node_result.is_ok(), f"Failed to create and start node: {create_node_result.err()}"
+        node = create_node_result.ok_value
+
+        try:
+            send_result = node.channel_send(UNKNOWN_CHANNEL_ID, create_message_bindings())
+            assert send_result.is_err(), f"channel_send on unknown channel must fail, got Ok({send_result.ok_value!r})"
+            assert f"unknown channel: {UNKNOWN_CHANNEL_ID}" in send_result.err(), f"unexpected error message: {send_result.err()!r}"
+
+            assert collector.events == [], f"expected no events, got: {collector.events}"
         finally:
             node.stop_and_destroy()


### PR DESCRIPTION
## Channel wrapper tests (RC01, RC02)

Adds the first channel-lifecycle tests, exercising the channel API **wrappers from the `logos-delivery-python-bindings` repo** (now vendored at `master` after the wrappers PR merged).

### Tests
- **RC01 — create channel; duplicate create rejected**: on a Core-mode node, `channel_create()` succeeds, and a second create with the same id errors with `channel already exists: <id>`.
- **RC02 — send on unknown channel**: `channel_send()` to an id that was never created errors with `unknown channel: <id>`.

Both attach an `EventCollector` and assert no events are emitted, matching the spec's "Expected events: none."

### Misc
- Bumped the `logos-delivery-python-bindings` submodule to `master`.
- Ignore SDS-generated `data/` files.

### Status
Both tests pass locally (`2 passed in 22s`). [CI job](https://logos-messaging.github.io/logos-delivery-interop-tests/nim/1313/)
