### PR TITLE
fix: adapt lightpush and filter tests to new nwaku default rate limits

### DIFF
--- a/tests/filter/test_subscribe_create.py
+++ b/tests/filter/test_subscribe_create.py
@@ -63,7 +63,7 @@ class TestFilterSubscribeCreate(StepsFilter):
         assert not failed_content_topics, f"ContentTopics failed: {failed_content_topics}"
 
     def test_filter_subscribe_to_29_content_topics_in_separate_calls(self, subscribe_main_nodes):
-        # subscribe_main_nodes already consumed 1 slot; make 29 more = 30 total, all must succeed
+        # subscribe_main_nodes already made 1 subscribe call; make 29 more = 30 total, all must succeed
         _29_content_topics = [str(i) for i in range(29)]
         for content_topic in _29_content_topics:
             self.create_filter_subscription({"requestId": str(uuid4()), "contentFilters": [content_topic], "pubsubTopic": self.test_pubsub_topic})
@@ -77,8 +77,8 @@ class TestFilterSubscribeCreate(StepsFilter):
                 logger.error(f"ContentTopic {content_topic} failed: {str(ex)}")
                 failed_content_topics.append(content_topic)
         assert not failed_content_topics, f"ContentTopics failed: {failed_content_topics}"
-        # Rate limit is a token bucket (30/min); keep calling beyond 30 until one is denied
-        rate_limited = False
+        # Default rate limit is filter:100/1s; sequential calls stay under it, so calls beyond 30 must succeed
+        failed_extra_calls = []
         for extra in range(1, 20):
             try:
                 self.create_filter_subscription(
@@ -86,11 +86,9 @@ class TestFilterSubscribeCreate(StepsFilter):
                 )
                 logger.debug(f"Extra subscribe call #{extra} succeeded")
             except Exception as ex:
-                assert "subscription failed" in str(ex) or "rate limit exceeded" in str(ex), f"Unexpected error on extra call #{extra}: {ex}"
-                logger.info(f"Rate limit hit on extra call #{extra}: {ex}")
-                rate_limited = True
-                break
-        assert rate_limited, "Rate limit was not triggered on any call beyond 30"
+                logger.error(f"Extra subscribe call #{extra} failed: {ex}")
+                failed_extra_calls.append(extra)
+        assert not failed_extra_calls, f"Subscribe calls beyond 30 were rate limited: {failed_extra_calls}"
 
     def test_filter_subscribe_to_101_content_topics(self, subscribe_main_nodes):
         try:

--- a/tests/light_push/test_publish.py
+++ b/tests/light_push/test_publish.py
@@ -29,6 +29,7 @@ class TestLightPushPublish(StepsLightPush):
         failed_payloads = []
         for payload in SAMPLE_INPUTS:
             logger.debug(f'Running test with payload {payload["description"]}')
+            delay(0.25)  # keep sends under the default lightpush:5/1s service rate limit
             message = self.create_message(payload=to_base64(payload["value"]))
             try:
                 self.check_light_pushed_message_reaches_receiving_peer(message=message)
@@ -88,6 +89,7 @@ class TestLightPushPublish(StepsLightPush):
         failed_content_topics = []
         for content_topic in SAMPLE_INPUTS:
             logger.debug(f'Running test with content topic {content_topic["description"]}')
+            delay(0.25)  # keep sends under the default lightpush:5/1s service rate limit
             message = self.create_message(contentTopic=content_topic["value"])
             try:
                 self.check_light_pushed_message_reaches_receiving_peer(message=message)

--- a/tests/light_push/test_publish.py
+++ b/tests/light_push/test_publish.py
@@ -29,7 +29,7 @@ class TestLightPushPublish(StepsLightPush):
         failed_payloads = []
         for payload in SAMPLE_INPUTS:
             logger.debug(f'Running test with payload {payload["description"]}')
-            delay(0.25)  # keep sends under the default lightpush:5/1s service rate limit
+            delay(0.5)
             message = self.create_message(payload=to_base64(payload["value"]))
             try:
                 self.check_light_pushed_message_reaches_receiving_peer(message=message)
@@ -89,7 +89,7 @@ class TestLightPushPublish(StepsLightPush):
         failed_content_topics = []
         for content_topic in SAMPLE_INPUTS:
             logger.debug(f'Running test with content topic {content_topic["description"]}')
-            delay(0.25)  # keep sends under the default lightpush:5/1s service rate limit
+            delay(0.5)
             message = self.create_message(contentTopic=content_topic["value"])
             try:
                 self.check_light_pushed_message_reaches_receiving_peer(message=message)


### PR DESCRIPTION
## PR Details
Since [#4015](https://github.com/logos-messaging/logos-delivery/pull/4015), nodes started without `--rate-limit` flags apply new default limits: `filter:100/1s, lightpush:5/1s`. Before, lightpush had no limit and filter allowed 30 requests/min.

Our test nodes don't set `--rate-limit`, so:

- lightpush tests send faster than 5 msg/s and now get 429 errors
- the filter test waits for a 429 after 30 subscribe calls, but that old 30/min limit no longer exists, so it never comes