### PR TITLE
Fix CI issue [reports / flaky tests]

### DIFF
--- a/.github/workflows/test_common.yml
+++ b/.github/workflows/test_common.yml
@@ -273,7 +273,7 @@ jobs:
           du -sh all-results || true
 
       - name: Setup allure report
-        uses: simple-elf/allure-report-action@master
+        uses: simple-elf/allure-report-action@v1.15
         if: always()
         id: allure-report
         with:

--- a/src/steps/filter.py
+++ b/src/steps/filter.py
@@ -18,7 +18,7 @@ logger = get_custom_logger(__name__)
 class StepsFilter(StepsCommon):
     test_pubsub_topic = VALID_PUBSUB_TOPICS[1]
     second_pubsub_topic = VALID_PUBSUB_TOPICS[2]
-    another_cluster_pubsub_topic = "/waku/2/rs/2/2"
+    another_cluster_pubsub_topic = "/waku/2/rs/199/2"
     test_content_topic = "/test/1/waku-filter/proto"
     second_content_topic = "/test/2/waku-filter/proto"
     test_payload = "Filter works!!"

--- a/src/test_data.py
+++ b/src/test_data.py
@@ -124,8 +124,10 @@ PUBSUB_TOPICS_STORE = [
 INVALID_PUBSUB_TOPICS = ["/test/2/rs/0/1", "/waku/3/rs/0/1", "/waku/2/test/0/1", "/waku/2/rs/3/b", "/waku/2/rs/0"]
 
 PUBSUB_TOPICS_DIFFERENT_CLUSTERS = [
-    "/waku/2/rs/2/0",
-    "/waku/2/rs/2/1",
+    # cluster 2 is the logos.dev default cluster with its own settings, so it is
+    # reserved; use the safe cluster 199 instead.
+    "/waku/2/rs/199/0",
+    "/waku/2/rs/199/1",
     "/waku/2/rs/5/0",
     "/waku/2/rs/5/1",
     "/waku/2/rs/5/999",

--- a/tests/sharding/test_relay_static_sharding.py
+++ b/tests/sharding/test_relay_static_sharding.py
@@ -22,8 +22,8 @@ class TestRelayStaticSharding(StepsSharding):
 
     def test_subscribe_and_publish_on_another_shard(self):
         self.setup_main_relay_nodes(pubsub_topic=self.test_pubsub_topic)
-        self.subscribe_main_relay_nodes(pubsub_topics=["/waku/2/rs/2/1"])
-        self.check_published_message_reaches_relay_peer(pubsub_topic="/waku/2/rs/2/1")
+        self.subscribe_main_relay_nodes(pubsub_topics=["/waku/2/rs/199/1"])
+        self.check_published_message_reaches_relay_peer(pubsub_topic="/waku/2/rs/199/1")
         try:
             self.check_published_message_reaches_relay_peer(pubsub_topic=self.test_pubsub_topic)
             if self.node2.is_nwaku():
@@ -36,7 +36,7 @@ class TestRelayStaticSharding(StepsSharding):
     def test_cant_publish_on_not_subscribed_shard(self):
         self.setup_main_relay_nodes(pubsub_topic=self.test_pubsub_topic)
         self.subscribe_main_relay_nodes(pubsub_topics=[self.test_pubsub_topic])
-        self.check_publish_fails_on_not_subscribed_pubsub_topic("/waku/2/rs/2/1")
+        self.check_publish_fails_on_not_subscribed_pubsub_topic("/waku/2/rs/199/1")
 
     def test_subscribe_via_api_to_new_pubsub_topics(self):
         self.setup_main_relay_nodes(pubsub_topic=PUBSUB_TOPICS_SAME_CLUSTER[:1])

--- a/tests/sharding/test_running_nodes_static_sharding.py
+++ b/tests/sharding/test_running_nodes_static_sharding.py
@@ -57,7 +57,8 @@ class TestRunningNodesStaticSharding(StepsSharding):
             assert f"Peer NODE_2:{NODE_2} couldn't find any messages" in str(ex)
 
     def test_start_node_with_50_pubsub_topics(self):
-        topics = ["/waku/2/rs/2/" + str(i) for i in range(50)]
+        # cluster 2 is the reserved logos.dev default cluster; use the safe cluster 199
+        topics = ["/waku/2/rs/199/" + str(i) for i in range(50)]
         self.setup_main_relay_nodes(pubsub_topic=topics)
         self.subscribe_main_relay_nodes(pubsub_topics=topics)
         for pubsub_topic in topics:


### PR DESCRIPTION
## Allure report

Pin `simple-elf/allure-report-action` from `@master` to `@v1.15`.

The `@master` image was missing `findutils` (no `xargs`), so `allure generate` produced no report and the deploy step failed. `v1.15` installs `findutils`, restoring report generation.

## Flaky sharding tests

Move sharding tests off cluster 2 onto the safe cluster 199.

Cluster 2 is the logos.dev default cluster with its own settings, so tests running on it behaved differently and went flaky. Sharding tests were already moved to cluster 199, but a few still targeted cluster 2. All swapped to cluster 199 (still a different cluster from the filter default 198, so the "another cluster" semantics are preserved).

Fixed tests:
- `test_single_pubsub_topic[/waku/2/rs/2/0]` (now `199/0`)
- `test_start_node_with_50_pubsub_topics`
- `test_subscribe_and_publish_on_another_shard`
- `test_cant_publish_on_not_subscribed_shard`
- `test_filter_subscribe_to_pubsub_topic_from_another_cluster_id`
- `test_filter_subscribe_to_pubsub_topics_from_multiple_clusters`

related [CI job](https://github.com/logos-messaging/logos-delivery-interop-tests/actions/runs/30131785747)